### PR TITLE
Remove active menu item styles

### DIFF
--- a/src/modules/menu.module/module.css
+++ b/src/modules/menu.module/module.css
@@ -38,7 +38,7 @@
 
 .menu__link--active-link,
 .menu__link--active-branch {
-  font-weight: bold;
+  /* Bold font weight removed for desktop menu */
 }
 
 @media (min-width: 768px) and (max-width: 1150px) {
@@ -68,12 +68,8 @@
 }
 
 .menu__item--depth-1 > .menu__link--active-link:after {
-  bottom: -3px;
-  content: '';
-  height: 2px;
-  left: 0;
-  position: absolute;
-  width: 100%;
+  /* Underline removed for desktop menu */
+  content: none;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Removes the bold text and underline styles for active pages in the desktop menu. This change provides a cleaner appearance for the currently active navigation item on desktop.

**Relevant links**

Example page:
GitHub issue:

**Checklist**

- [ ] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ ] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->

---
<a href="https://cursor.com/background-agent?bcId=bc-6e5830cd-5792-47e6-9d3b-a720c09c7527">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e5830cd-5792-47e6-9d3b-a720c09c7527">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>