### PR TITLE
Align mobile menu items to the left

### DIFF
--- a/src/modules/menu.module/module.css
+++ b/src/modules/menu.module/module.css
@@ -51,7 +51,7 @@
   .menu__wrapper {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-around;
+    justify-content: flex-start;
   }
 
   .menu__item {
@@ -83,12 +83,12 @@
   .menu__item--depth-1 {
     border-top: none;
     padding: 0;
-    margin: 0 0.25rem;
+    margin: 0 1rem 0 0;
   }
 
   .menu__item--depth-1 > .menu__link {
     padding: 0.35rem 0.5rem;
-    text-align: center;
+    text-align: left;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This PR aligns mobile menu items to the left and adds more spacing between them, improving the visual layout and readability on mobile devices.

Specifically, it modifies the `menu.module/module.css` to:
- Change `justify-content` from `space-around` to `flex-start` for `.menu__wrapper` on mobile.
- Adjust `margin` for `.menu__item--depth-1` to `0 1rem 0 0` for increased spacing.
- Set `text-align` to `left` for `.menu__item--depth-1 > .menu__link`.

**Relevant links**

Example page:
GitHub issue:

**Checklist**

- [ ] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ ] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->

---
<a href="https://cursor.com/background-agent?bcId=bc-4b8d0181-8b88-48f1-a581-103f403528b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b8d0181-8b88-48f1-a581-103f403528b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>