### PR TITLE
Adjust main theme width to 600px

### DIFF
--- a/src/fields.json
+++ b/src/fields.json
@@ -116,7 +116,7 @@
         "type": "number",
         "display": "slider",
         "max": 2500,
-        "min": 900,
+        "min": 600,
         "suffix": "px",
         "default": 1240
       }


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This PR updates the main theme's adjustable content width by changing the minimum allowed value for "Maximum content width" in `src/fields.json` from 900px to 600px. This provides greater flexibility, allowing users to configure narrower content layouts for improved responsive design.

**Relevant links**

Example page:
GitHub issue:

**Checklist**

- [ ] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ ] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->

---
<a href="https://cursor.com/background-agent?bcId=bc-f93edb88-3bcd-4f26-8366-7d5d13579bf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f93edb88-3bcd-4f26-8366-7d5d13579bf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

